### PR TITLE
Updated EditBox API such that a callback must be supplied for both in…

### DIFF
--- a/ExampleRibbon/Ribbon.vb
+++ b/ExampleRibbon/Ribbon.vb
@@ -118,10 +118,12 @@ Public Class Ribbon
 			WithSuperTip("You can edit this text, and the updated text will be displayed in the status bar!").
 			AsWideAs("Some Text This Big").
 			WithText("Edit Me!", AddressOf GetText, AddressOf OnChange).
-			WithTextValidationRule(Function(text) Not text.Contains("  "), "Double-Spaces Aren't Allowed!").
 			Build()
 
-		AddHandler textBox.TextChanged, AddressOf TextChangeEventHandler
+		With textBox
+			AddHandler .BeforeTextChange, AddressOf TextBoxValidation
+			AddHandler .TextChanged, AddressOf TextChangeEventHandler
+		End With
 
 		Dim textBoxGroup As Group = New GroupBuilder().WithLabel("Editable Text").WithControl(textBox).Build()
 
@@ -257,8 +259,15 @@ Public Class Ribbon
 		End Try
 	End Sub
 
+	Private Sub TextBoxValidation(sender As Object, e As EditBox.BeforeTextChangeEventArgs)
+		If e.NewText.Contains("  ") Then
+			DisplayStatusBarMessage("Double-spaces are not allowed!")
+			e.Cancel = True
+		End If
+	End Sub
+
 	Private Sub TextChangeEventHandler(sender As Object, e As EditBox.TextChangedEventArgs)
-		DisplayStatusBarMessage(If(e.IsSuccess, $"Text was changed to '{e.Text}'.", e.ErrorMessage))
+		DisplayStatusBarMessage($"Text was changed to '{e.NewText}'.")
 	End Sub
 
 	Private _source As CancellationTokenSource

--- a/RibbonFactory/Builders/EditBoxBuilder.vb
+++ b/RibbonFactory/Builders/EditBoxBuilder.vb
@@ -4,7 +4,6 @@ Imports RibbonFactory.Controls
 Imports RibbonFactory.Enums.ImageMSO
 Imports RibbonFactory.Enums.MSO
 Imports RibbonFactory.RibbonAttributes
-Imports RibbonFactory.Utilities.Validation
 Imports stdole
 
 Namespace Builders
@@ -21,19 +20,14 @@ Namespace Builders
         Implements IShowLabel(Of EditBoxBuilder)
         Implements IMaxLength(Of EditBoxBuilder)
         Implements ISizeString(Of EditBoxBuilder)
-        Implements IOnChange(Of EditBox, EditBoxBuilder)
-        Implements IValidateText(Of EditBoxBuilder)
 
         Private ReadOnly _builder As ControlBuilder
-        Private ReadOnly _validationRules As ICollection(Of IValidate(Of String))
 
         Public Sub New()
             Dim defaultProvider As IDefaultProvider = New DefaultProvider(Of EditBox)
             Dim attributeGroupBuilder As AttributeGroupBuilder = New AttributeGroupBuilder()
             attributeGroupBuilder.SetDefaults(defaultProvider)
             _builder = New ControlBuilder(attributeGroupBuilder)
-
-            _validationRules = New List(Of IValidate(Of String))
         End Sub
 
         Public Sub New(template As EditBox)
@@ -41,7 +35,6 @@ Namespace Builders
             attributeGroupBuilder.SetDefaults(template)
             attributeGroupBuilder.AddID(IdManager.GetID(Of EditBox)())
             _builder = New ControlBuilder(attributeGroupBuilder)
-            _validationRules = New List(Of IValidate(Of String))
         End Sub
 
         Public Sub New(template As RibbonElement)
@@ -54,14 +47,13 @@ Namespace Builders
                 Dim attributeGroupBuilder As AttributeGroupBuilder = New AttributeGroupBuilder(intersection)
                 attributeGroupBuilder.AddID(IdManager.GetID(Of EditBox)())
                 _builder = New ControlBuilder(attributeGroupBuilder)
-                _validationRules = New List(Of IValidate(Of String))
             Else
                 Throw New ArgumentException($"Could not copy applicable properties of type '{template.GetType().Name}' to type '{GetType(EditBox)}'")
             End If
         End Sub
 
         Public Function Build(Optional tag As Object = Nothing) As EditBox Implements IBuilder(Of EditBox).Build
-            Return New EditBox(_builder.Build(), _validationRules.ToArray(), tag:=tag)
+            Return New EditBox(_builder.Build(), tag:=tag)
         End Function
 
         Public Function Enabled() As EditBoxBuilder Implements IEnabled(Of EditBoxBuilder).Enabled
@@ -191,11 +183,6 @@ Namespace Builders
             Return Me
         End Function
 
-        Public Function ThatDoes(action As Action(Of EditBox), callback As TextChanged) As EditBoxBuilder Implements IOnChange(Of EditBox, EditBoxBuilder).ThatDoes
-            _builder.ThatDoes(action, callback)
-            Return Me
-        End Function
-
         Public Function WithText(text As String, getText As FromControl(Of String), setText As TextChanged) As EditBoxBuilder
             _builder.GetTextFrom(text, getText)
             _builder.ThatDoes(Of EditBox)(Sub(eb) Return, setText)
@@ -219,15 +206,6 @@ Namespace Builders
 
         Public Function InsertAfterQ(qualifiedControl As RibbonElement) As EditBoxBuilder Implements IInsert(Of EditBoxBuilder).InsertAfter
             _builder.InsertAfter(qualifiedControl)
-            Return Me
-        End Function
-
-        Public Function WithTextValidationRule(rule As Predicate(Of String)) As EditBoxBuilder Implements IValidateText(Of EditBoxBuilder).WithTextValidationRule
-            Return WithTextValidationRule(rule, String.Empty)
-        End Function
-
-        Public Function WithTextValidationRule(rule As Predicate(Of String), failureMessage As String) As EditBoxBuilder Implements IValidateText(Of EditBoxBuilder).WithTextValidationRule
-            _validationRules.Add(New TextValidator(rule, failureMessage))
             Return Me
         End Function
 

--- a/RibbonFactory/Utilities/StockRibbonBase.vb
+++ b/RibbonFactory/Utilities/StockRibbonBase.vb
@@ -175,7 +175,6 @@ Namespace Utilities
 
         Public Sub OnChange(control As IRibbonControl, text As String) Implements ICreateCallbacks.OnChange
             Ribbon.GetElement(Of IText)(control.Id).Text = text
-            Ribbon.GetElement(Of IOnAction)(control.Id).Execute() 'TODO API for this is a bit awkward. Putting this in the Setter won't work. Maybe move this to a separate callback?
         End Sub
 
         Public Sub OnSelectionChange(control As IRibbonControl, selectedId As String, selectedIndex As Integer) Implements ICreateCallbacks.OnSelectionChange


### PR DESCRIPTION
…coming and outgoing text changes at the same time. Switched to using events instead of delegates for text validation.